### PR TITLE
Update from `generate-script` to `ndm generate`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ You should now have a functional private registry, that's all there is to it!
   1. `cd /etc/npme`
   2. run: `service redis-server start | service nginx start | couchdb | npme restart | tail -f ./logs/*`
 3. to experiment with configuration changes:
-  1. edit `/etc/npme/service.json`.
-  2. run `generate-scripts`.
-  3. start npm Enterprise (`service redis-server start | service nginx start | couchdb | npme restart | tail -f ./logs/*`).
+  1. `cd /etc/npme`
+  2. edit `/etc/npme/service.json`.
+  3. run `ndm generate`.
+  4. start npm Enterprise (`service redis-server start | service nginx start | couchdb | npme restart | tail -f ./logs/*`).
 
 ## Tips and Tricks
 


### PR DESCRIPTION
`generate-script` does not exists in this container's PATH. There is no file named generate-script in the filesystem. However, ndm contains a  'generate-script' command in it's package.json. Given this I assumed the intent of this line is to run `ndm generate`. Running `ndm generate` successfully updated the daemon configuration changes from service.json.