### PR TITLE
if the beam process dies, start it up again

### DIFF
--- a/replicated/policy-follower-cron
+++ b/replicated/policy-follower-cron
@@ -1,1 +1,2 @@
 * * * * * root /usr/bin/npme start >> /var/log/cron.log 2>&1
+* * * * * root curl localhost:5984 || couchdb >> /var/log/cron.log 2>&1


### PR DESCRIPTION
One npm-o customer has had an issue where the beam process falls over inside the docker container. This change is a stop-gap until we can dig further. Potential solutions:

* break CouchDB out into its own docker container.
* switch to a user-land orchestration library ... monit perhaps?