### PR TITLE
make it possible to configure upstream npm-o to npm-o replication

### DIFF
--- a/replicated/Dockerfile.replicated
+++ b/replicated/Dockerfile.replicated
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:4.2.1
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/policy-follower/start.sh
+++ b/replicated/policy-follower/start.sh
@@ -7,7 +7,7 @@ fi
 
 cd /etc/npme/node_modules/@npm/policy-follower/
 if [ -n "$PROXY_URL" ]; then
-  node ./bin/policy-follower.js start --policy=$POLICY --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --proxy=$PROXY_URL
+  node ./bin/policy-follower.js start --policy=$POLICY --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --proxy=$PROXY_URL --send-shared-fetch-secret-to-remote-couch=$SEND_SHARED_FETCH_SECRET
 else
-  node ./bin/policy-follower.js start --policy=$POLICY --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH
+  node ./bin/policy-follower.js start --policy=$POLICY --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --send-shared-fetch-secret-to-remote-couch=$SEND_SHARED_FETCH_SECRET
 fi

--- a/replicated/policy-follower/start.sh
+++ b/replicated/policy-follower/start.sh
@@ -7,7 +7,7 @@ fi
 
 cd /etc/npme/node_modules/@npm/policy-follower/
 if [ -n "$PROXY_URL" ]; then
-  node ./bin/policy-follower.js start --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --proxy=$PROXY_URL
+  node ./bin/policy-follower.js start --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --proxy=$PROXY_URL --send-shared-fetch-secret-to-remote-couch=$SEND_SHARED_FETCH_SECRET
 else
-  node ./bin/policy-follower.js start --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH
+  node ./bin/policy-follower.js start --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --send-shared-fetch-secret-to-remote-couch=$SEND_SHARED_FETCH_SECRET
 fi

--- a/replicated/policy-follower/start.sh
+++ b/replicated/policy-follower/start.sh
@@ -7,7 +7,7 @@ fi
 
 cd /etc/npme/node_modules/@npm/policy-follower/
 if [ -n "$PROXY_URL" ]; then
-  node ./bin/policy-follower.js start --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --proxy=$PROXY_URL --send-shared-fetch-secret-to-remote-couch=$SEND_SHARED_FETCH_SECRET
+  node ./bin/policy-follower.js start --policy=$POLICY --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --proxy=$PROXY_URL
 else
-  node ./bin/policy-follower.js start --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH --send-shared-fetch-secret-to-remote-couch=$SEND_SHARED_FETCH_SECRET
+  node ./bin/policy-follower.js start --policy=$POLICY --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --seq-file=$SEQ_FILE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --white-list-path=$WHITELIST_PATH
 fi

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -476,7 +476,7 @@ components:
     - host_path: '{{repl ConfigOption "data_host_path" }}'
       container_path: /etc/npme/data
     support_files:
-      - /etc/npme/node_modules/@npm/registry-frontdoor/data/usage.txt
+      - filename: /etc/npme/node_modules/@npm/registry-frontdoor/data/usage.txt
     support_commands: []
   - source: replicated
     image_name: postgres

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -21,14 +21,14 @@ admin_commands:
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.11'
+    version: '1.0.12'
 - alias: add-package
   command: [sh, /etc/npme/manage-whitelist.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.11'
+    version: '1.0.12'
 - alias: ssh
   run_type: exec
   command: [/bin/sh]
@@ -165,7 +165,7 @@ components:
     support_files: []
   - source: replicated
     image_name: policy-follower
-    version: '1.0.11'
+    version: '1.0.12'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -620,6 +620,7 @@ components:
     config_files:
       - filename: /etc/npme/node_modules/newww/.env
         contents: |-
+          NPMO_COBRAND='{{repl ConfigOption "branding" }}'
           CANONICAL_HOST=http://localhost:8081
           DOWNLOADS_API=https://api.npmjs.org/downloads
           ELASTICSEARCH_URL=http://{{repl ThisHostInterfaceAddress "docker0" }}:9200/npm
@@ -700,6 +701,10 @@ config:
     title: Full URL of npm Enterprise host
     type: text
     value: http://{{repl ConfigOption "publicip" }}:8080
+  - name: branding
+    title: Your company name
+    type: text
+    default: 'FakeCorp'
   - name: publicip
     type: text
     hidden: true

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -21,14 +21,14 @@ admin_commands:
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.10'
+    version: '1.0.11'
 - alias: add-package
   command: [sh, /etc/npme/manage-whitelist.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.10'
+    version: '1.0.11'
 - alias: ssh
   run_type: exec
   command: [/bin/sh]
@@ -165,7 +165,7 @@ components:
     support_files: []
   - source: replicated
     image_name: policy-follower
-    version: '1.0.10'
+    version: '1.0.11'
     privileged: false
     restart:
       policy: on-failure
@@ -189,6 +189,9 @@ components:
         is_excluded_from_support: true
       - name: COUCH_URL_REMOTE
         static_val: '{{repl ConfigOption "couch_url_remote" }}'
+        is_excluded_from_support: true
+      - name: POLICY
+        static_val: '{{repl ConfigOption "remote_policy" }}'
         is_excluded_from_support: true
       - name: SEND_SHARED_FETCH_SECRET
         static_val: '{{repl if ConfigOptionEquals "remote_shared_fetch_secret" ""}}{{repl else }}true{{repl end }}'
@@ -797,6 +800,10 @@ config:
     title: upstream secret (only required for replicating from upstream npm On-Site servers)
     type: text
     default: ''
+  - name: remote_policy
+    title: policy to apply during replication (set to mirror to create a true replica).
+    type: text
+    default: 'white-list'
 - name: authfetch
   title: Auth reads
   description: Should npm installs require an token?

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -14,28 +14,28 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.17'
+    version: '1.0.18'
 - alias: reset-follower
   command: [sh, /etc/npme/reset-follower.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.9'
+    version: '1.0.10'
 - alias: add-package
   command: [sh, /etc/npme/manage-whitelist.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.9'
+    version: '1.0.10'
 - alias: ssh
   run_type: exec
   command: [/bin/sh]
   component: npme
   image:
     image_name: npme
-    version: '1.0.17'
+    version: '1.0.18'
 state:
   ready: null
 backup:
@@ -165,7 +165,7 @@ components:
     support_files: []
   - source: replicated
     image_name: policy-follower
-    version: '1.0.9'
+    version: '1.0.10'
     privileged: false
     restart:
       policy: on-failure
@@ -181,9 +181,6 @@ components:
       - name: FRONT_DOOR_HOST
         static_val: '{{repl ConfigOption "canonical_url" }}'
         is_excluded_from_support: true
-      - name: SHARED_FETCH_SECRET
-        static_val: '{{repl ConfigOption "secret" }}'
-        is_excluded_from_support: true
       - name: REJECT_UNAUTHORIZED
         static_val: '{{repl if ConfigOptionEquals "reject_unauthorized" "reject_unauthorized_no" }}0{{repl else }}1{{repl end }}'
         is_excluded_from_support: true
@@ -192,6 +189,12 @@ components:
         is_excluded_from_support: true
       - name: COUCH_URL_REMOTE
         static_val: '{{repl ConfigOption "couch_url_remote" }}'
+        is_excluded_from_support: true
+      - name: SEND_SHARED_FETCH_SECRET
+        static_val: '{{repl if ConfigOptionEquals "remote_shared_fetch_secret" ""}}false{{repl else }}true{{repl end }}'
+        is_excluded_from_support: true
+      - name: SHARED_FETCH_SECRET
+        static_val: '{{repl ConfigOption "remote_shared_fetch_secret" }}'
         is_excluded_from_support: true
       - name: SEQ_FILE
         static_val: '/etc/npme/data/sequence'
@@ -328,7 +331,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npme
-    version: '1.0.17'
+    version: '1.0.18'
     privileged: false
     restart:
       policy: on-failure
@@ -604,7 +607,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.0.1'
+    version: '1.0.2'
     privileged: false
     restart:
       policy: on-failure
@@ -784,6 +787,9 @@ config:
   - name: couch_url_remote
     type: text
     default: https://skimdb.npmjs.com/registry
+  - name: remote_shared_fetch_secret
+    type: text
+    default: ''
 - name: authfetch
   title: Auth reads
   description: Should npm installs require an token?

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -191,7 +191,7 @@ components:
         static_val: '{{repl ConfigOption "couch_url_remote" }}'
         is_excluded_from_support: true
       - name: SEND_SHARED_FETCH_SECRET
-        static_val: '{{repl if ConfigOptionEquals "remote_shared_fetch_secret" ""}}false{{repl else }}true{{repl end }}'
+        static_val: '{{repl if ConfigOptionEquals "remote_shared_fetch_secret" ""}}{{repl else }}true{{repl end }}'
         is_excluded_from_support: true
       - name: SHARED_FETCH_SECRET
         static_val: '{{repl ConfigOption "remote_shared_fetch_secret" }}'
@@ -791,8 +791,10 @@ config:
   items:
   - name: couch_url_remote
     type: text
+    title: upstream url
     default: https://skimdb.npmjs.com/registry
   - name: remote_shared_fetch_secret
+    title: upstream secret (only required for replicating from upstream npm On-Site servers)
     type: text
     default: ''
 - name: authfetch

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -789,8 +789,8 @@ config:
       affix: right
       required: false
 - name: couch_url_remote
-  title: Upstream couchdb
-  description: Which upstream couchdb should we replicate from?
+  title: Upstream registry
+  description: Which upstream registry should we replicate from?
   items:
   - name: couch_url_remote
     type: text

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -14,7 +14,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.18'
+    version: '1.0.19'
 - alias: reset-follower
   command: [sh, /etc/npme/reset-follower.sh]
   run_type: exec
@@ -35,7 +35,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.18'
+    version: '1.0.19'
 state:
   ready: null
 backup:
@@ -334,7 +334,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npme
-    version: '1.0.18'
+    version: '1.0.19'
     privileged: false
     restart:
       policy: on-failure


### PR DESCRIPTION
* adds support for npmO :arrow_right: npmO replication.
* adds a configuration setting for @aredridel's branding work.
* switches registry-frontdoor to node@4.x (I was running into hanging issues during stress testing).