### PR TITLE
fix for read-through-cache problems

### DIFF
--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -14,7 +14,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.20'
+    version: '1.0.21'
 - alias: reset-follower
   command: [sh, /etc/npme/reset-follower.sh]
   run_type: exec
@@ -35,7 +35,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.20'
+    version: '1.0.21'
 state:
   ready: null
 backup:
@@ -334,7 +334,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npme
-    version: '1.0.20'
+    version: '1.0.21'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -448,7 +448,7 @@ components:
         static_val: 'http://{{repl ThisHostInterfaceAddress "docker0" }}:5001'
         is_excluded_from_support: true
       - name: READ_THROUGH_CACHE
-        static_val: '"{{repl if ConfigOptionEquals "read_through_cache" "read_through_cache_no" }}false{{repl else }}true{{repl end}}'
+        static_val: '{{repl if ConfigOptionEquals "read_through_cache" "read_through_cache_no" }}false{{repl else }}true{{repl end}}'
         is_excluded_from_support: true
       - name: PROXY_URL
         static_val: '{{repl ConfigOption "proxy_url" }}'

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -14,7 +14,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.19'
+    version: '1.0.20'
 - alias: reset-follower
   command: [sh, /etc/npme/reset-follower.sh]
   run_type: exec
@@ -35,7 +35,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.19'
+    version: '1.0.20'
 state:
   ready: null
 backup:
@@ -334,7 +334,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npme
-    version: '1.0.19'
+    version: '1.0.20'
     privileged: false
     restart:
       policy: on-failure
@@ -461,6 +461,9 @@ components:
         is_excluded_from_support: true
       - name: COUCH_URL_REMOTE
         static_val: '{{repl ConfigOption "couch_url_remote" }}'
+        is_excluded_from_support: true
+      - name: BINARY_DIRECTORY
+        static_val: '/etc/npme/packages'
         is_excluded_from_support: true
       - name: BINARIES_HOST
         static_val: 'http://{{repl ThisHostInterfaceAddress "docker0" }}:8000'

--- a/replicated/start.sh
+++ b/replicated/start.sh
@@ -10,7 +10,7 @@ fi
 
 cd /etc/npme/node_modules/@npm/registry-frontdoor/
 if [ -n "$PROXY_URL" ]; then
-  node ./bin/registry-frontdoor.js start --binaries-host=$BINARIES_HOST --proxy=$PROXY_URL --auth-host=$AUTH_HOST --reject-unauthorized=$REJECT_UNAUTHORIZED --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --read-through-cache=$READ_THROUGH_CACHE --auth-fetch=$AUTH_FETCH --port=8080 --host=0.0.0.0
+  node ./bin/registry-frontdoor.js start --binary-directory=$BINARY_DIRECTORY --binaries-host=$BINARIES_HOST --proxy=$PROXY_URL --auth-host=$AUTH_HOST --reject-unauthorized=$REJECT_UNAUTHORIZED --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --read-through-cache=$READ_THROUGH_CACHE --auth-fetch=$AUTH_FETCH --port=8080 --host=0.0.0.0
 else
-  node ./bin/registry-frontdoor.js start --binaries-host=$BINARIES_HOST --auth-host=$AUTH_HOST --reject-unauthorized=$REJECT_UNAUTHORIZED --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --read-through-cache=$READ_THROUGH_CACHE --auth-fetch=$AUTH_FETCH --port=8080 --host=0.0.0.0
+  node ./bin/registry-frontdoor.js start --binary-directory=$BINARY_DIRECTORY --binaries-host=$BINARIES_HOST --auth-host=$AUTH_HOST --reject-unauthorized=$REJECT_UNAUTHORIZED --front-door-host=$FRONT_DOOR_HOST --shared-fetch-secret=$SHARED_FETCH_SECRET --couch-url=$COUCH_URL --couch-url-remote=$COUCH_URL_REMOTE --validate-host=$VALIDATE_HOST --front-door-host=$FRONT_DOOR_HOST --read-through-cache=$READ_THROUGH_CACHE --auth-fetch=$AUTH_FETCH --port=8080 --host=0.0.0.0
 fi


### PR DESCRIPTION
The problems we were observing with the read-through-cache relate to the binary directory variable not being set.