### PR TITLE
policy-follower should mount packages directory

### DIFF
--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -194,6 +194,9 @@ components:
       - name: REJECT_UNAUTHORIZED
         static_val: '{{repl if ConfigOptionEquals "reject_unauthorized" "reject_unauthorized_no" }}0{{repl else }}1{{repl end }}'
         is_excluded_from_support: true
+      - name: BINARY_DIRECTORY
+        static_val: '/etc/npme/packages'
+        is_excluded_from_support: true
       - name: COUCH_URL
         static_val: 'http://admin:admin@{{repl ThisHostInterfaceAddress "docker0" }}:5984/registry'
         is_excluded_from_support: true
@@ -222,8 +225,10 @@ components:
         is_excluded_from_support: true
     ports: []
     volumes:
-    - host_path: '{{repl ConfigOption "data_host_path" }}'
-      container_path: /etc/npme/data
+      - host_path: '{{repl ConfigOption "data_host_path" }}'
+        container_path: /etc/npme/data
+      - host_path: '{{repl ConfigOption "packages_host_path" }}'
+        container_path: /etc/npme/packages
     support_files: []
   - source: public
     image_name: klaemo/couchdb
@@ -399,32 +404,6 @@ components:
     - filename: /etc/npme/.license.json
       contents: |-
         {{repl LicenseFieldValue "license_json" }}
-    - filename: /etc/npme/service.json
-      contents: |-
-        {
-          "env": {
-            "LOGIN_CACHE_REDIS": "redis://{{repl ThisHostInterfaceAddress "docker0" }}:6379"
-          },
-          "args": {
-            "--front-door-host": "{{repl ConfigOption "canonical_url" }}",
-            "--white-list-path": "/etc/npme/data/whitelist",
-            "--github-host": {{repl if ConfigOptionEquals "github_type" "github_type_public" }}"https://api.github.com"{{repl else }}"https://{{repl ConfigOption "github_enterprise_host" }}"{{repl end }},
-            "--shared-fetch-secret": "{{repl ConfigOption "secret" }}",
-            "--binary-directory": "/etc/npme/packages",
-            "--binaries-host": "http://{{repl ThisHostInterfaceAddress "docker0" }}:8000",
-            "--auth-fetch": "{{repl if ConfigOptionEquals "authfetch" "authfetch_no" }}false{{repl else }}true{{repl end}}",
-            "--authentication-method": "{{repl ConfigOption "authentication" }}",
-            "--authorization-method": "{{repl ConfigOption "authorization" }}",
-            "--session-handler": "{{repl ConfigOption "session" }}",
-            "--read-through-cache": "{{repl if ConfigOptionEquals "read_through_cache" "read_through_cache_no" }}false{{repl else }}true{{repl end}}",
-            {{repl if ConfigOptionNotEquals "proxy_url" ""}}"--proxy-url": "{{repl ConfigOption "proxy_url" }}",{{repl end}}
-            {{repl if ConfigOptionEquals "reject_unauthorized" "reject_unauthorized_no" }}"--reject-unauthorized": "0",{{repl end}}
-            "--couch-url-remote": "{{repl ConfigOption "couch_url_remote" }}",
-            "--couch-url": "http://admin:admin@{{repl ThisHostInterfaceAddress "docker0" }}:5984/registry",
-            "--auth-host": "http://{{repl ThisHostInterfaceAddress "docker0" }}:5000",
-            "--validate-host": "http://{{repl ThisHostInterfaceAddress "docker0" }}:5001"
-          }
-        }
     customer_files: []
     env_vars:
       - name: FRONT_DOOR_HOST


### PR DESCRIPTION
the `remove-package` script on the policy follower requires access to the `/packages` mount.