### PR TITLE
feat: allow registry port to be configurable

### DIFF
--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -860,7 +860,7 @@ config:
   - name: canonical_url
     title: Full URL of npm Enterprise registry
     type: text
-    value: '{{repl ConfigOption "registry_base_url" }}:{{repl ConfigOption "registry_port" }}'
+    default: '{{repl ConfigOption "registry_base_url" }}:{{repl ConfigOption "registry_port" }}'
     readonly: true
   - name: website_url
     title: Full URL of npm Enterprise website (8081 must stay constant, you may optionally change the IP to a pretty host name)

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -847,21 +847,14 @@ config:
   title: "General"
   description: "Configure your npm Enterprise installation"
   items:
-  - name: registry_base_url
-    title: Registry Base URL
-    type: text
-    value: http://{{repl ConfigOption "publicip" }}
-    affix: left
-  - name: registry_port
-    title: Registry Port
-    type: text
-    value: 8080
-    affix: right
   - name: canonical_url
-    title: Full URL of npm Enterprise registry
+    title: Registry URL (This may point to the registry itself or a service fronting the registry)
     type: text
-    default: '{{repl ConfigOption "registry_base_url" }}:{{repl ConfigOption "registry_port" }}'
-    readonly: true
+    value: http://{{repl ConfigOption "publicip" }}:8080
+  - name: registry_port
+    title: Registry Port (Which port the registry should bind to on the host, regardless of URL)
+    type: text
+    default: 8080
   - name: website_url
     title: Full URL of npm Enterprise website (8081 must stay constant, you may optionally change the IP to a pretty host name)
     type: text

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -528,7 +528,7 @@ components:
         is_excluded_from_support: true
     ports:
     - private_port: "8080"
-      public_port: "8080"
+      public_port: '{{repl ConfigOption "registry_port" }}'
       port_type: tcp
       when: ""
     volumes:
@@ -847,10 +847,21 @@ config:
   title: "General"
   description: "Configure your npm Enterprise installation"
   items:
-  - name: canonical_url
-    title: Full URL of npm Enterprise registry (8080 must stay constant, you may optionally change the IP to a pretty host name)
+  - name: registry_base_url
+    title: Registry Base URL
     type: text
-    value: http://{{repl ConfigOption "publicip" }}:8080
+    value: http://{{repl ConfigOption "publicip" }}
+    affix: left
+  - name: registry_port
+    title: Registry Port
+    type: text
+    value: 8080
+    affix: right
+  - name: canonical_url
+    title: Full URL of npm Enterprise registry
+    type: text
+    value: '{{repl ConfigOption "registry_base_url" }}:{{repl ConfigOption "registry_port" }}'
+    readonly: true
   - name: website_url
     title: Full URL of npm Enterprise website (8081 must stay constant, you may optionally change the IP to a pretty host name)
     type: text


### PR DESCRIPTION
Should make it easier to work with colocated services or front with a cache like Varnish

Just an idea I wanted to play with, currently WIP

~~**NOTE** The port binding works, but the `canonical_url` is not built/propagated correctly, needs some work.~~