### PR TITLE
feat: configurable authz caching

### DIFF
--- a/replicated/npm-auth-ws/Dockerfile
+++ b/replicated/npm-auth-ws/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:4.4.4
+FROM mhart/alpine-node:4.7.2
 
 # File Author / Maintainer
 MAINTAINER Ben Coe
@@ -8,7 +8,7 @@ COPY ./replicated/npm-auth-ws/start.sh /etc/npme/start.sh
 WORKDIR /etc/npme
 
 RUN echo '@npm:registry=https://enterprise.npmjs.com/' > ~/.npmrc
-RUN npm install @npm/npm-auth-ws@3.4.1
+RUN npm install @npm/npm-auth-ws@3.5.1
 RUN npm install @npm/npmo-auth-token@1.2.2 -g
 
 CMD ["/etc/npme/start.sh"]

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -13,8 +13,8 @@ admin_commands:
   run_type: exec
   component: npme
   image:
-    image_name: npm-auth-ws
-    version: '2.6.1'
+    image_name: npmjs/npm-auth-ws
+    version: '2.7.0'
 - alias: update-license
   command: [sh, /usr/local/bin/npme-update-license.sh]
   run_type: exec
@@ -130,9 +130,9 @@ components:
       - hostname: '{{repl ConfigOption "etc_hosts_2_host" }}'
         address: '{{repl ConfigOption "etc_hosts_2_ip" }}'
         when: '{{repl ConfigOptionNotEquals "etc_hosts_2_ip" "" }}'
-  - source: replicated
-    image_name: npm-auth-ws
-    version: '2.6.1'
+  - source: public
+    image_name: npmjs/npm-auth-ws
+    version: '2.7.0'
     name: npme-auth
     privileged: false
     restart:
@@ -148,31 +148,23 @@ components:
     env_vars:
       - name: FRONT_DOOR_HOST
         static_val: '{{repl ConfigOption "canonical_url" }}'
-        is_excluded_from_support: true
       - name: GITHUB_ORG
         static_val: '{{repl ConfigOption "github_org" }}'
-        is_excluded_from_support: true
       - name: GITHUB_HOST
         static_val: '{{repl if ConfigOptionEquals "github_type" "github_type_public" }}https://api.github.com{{repl else }}{{repl if ConfigOptionEquals "github_enterprise_protocol" "github_enterprise_protocol_https"}}https{{repl else}}http{{repl end}}://{{repl ConfigOption "github_enterprise_host" }}{{repl end}}'
-        is_excluded_from_support: true
       - name: SHARED_FETCH_SECRET
         static_val: '{{repl ConfigOption "secret" }}'
         is_excluded_from_support: true
       - name: AUTHENTICATION_METHOD
         static_val: '{{repl if ConfigOptionEquals "auth_source" "auth_type_oauth2"}}oauth2{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_github"}}github{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_ldap"}}ldap{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_saml"}}sso{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_open"}}fake{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_bitbucket"}}bitbucket{{repl else}}{{repl ConfigOption "authentication" }}{{repl end}}{{repl end}}{{repl end}}{{repl end}}{{repl end}}{{repl end}}'
-        is_excluded_from_support: true
       - name: AUTHORIZATION_METHOD
         static_val: '{{repl if ConfigOptionEquals "auth_source" "auth_type_oauth2"}}oauth2{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_github"}}github{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_ldap"}}ldap{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_saml"}}sso{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_open"}}fake{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_bitbucket"}}bitbucket{{repl else}}{{repl ConfigOption "authorization" }}{{repl end}}{{repl end}}{{repl end}}{{repl end}}{{repl end}}{{repl end}}'
-        is_excluded_from_support: true
       - name: SESSION_HANDLER
         static_val: '{{repl if ConfigOptionEquals "auth_source" "auth_type_oauth2"}}oauth2{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_github"}}github{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_ldap"}}ldap{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_open"}}redis{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_saml"}}sso{{repl else}}{{repl if ConfigOptionEquals "auth_source" "auth_type_bitbucket"}}bitbucket{{repl else}}{{repl ConfigOption "session" }}{{repl end}}{{repl end}}{{repl end}}{{repl end}}{{repl end}}{{repl end}}'
-        is_excluded_from_support: true
       - name: REJECT_UNAUTHORIZED
         static_val: '{{repl if ConfigOptionEquals "reject_unauthorized" "reject_unauthorized_no" }}0{{repl else }}1{{repl end }}'
-        is_excluded_from_support: true
       - name: LOGIN_CACHE_REDIS
         static_val: 'redis://{{repl ThisHostInterfaceAddress "docker0" }}:6379'
-        is_excluded_from_support: true
       - name: CERTIFICATE
         static_val: '{{repl if ConfigOption "saml_certificate_raw"}}{{repl ConfigOption "saml_certificate_raw" | Base64Encode}}{{repl else}}{{repl ConfigOption "saml_certificate"}}{{repl end }}'
       - name: REDIS_URL
@@ -217,6 +209,10 @@ components:
         static_val: '{{repl ConfigOption "oauth2_email_key" }}'
       - name: OAUTH2_USER_KEY
         static_val: '{{repl ConfigOption "oauth2_user_key" }}'
+      - name: AUTHZ_CACHE_ENABLED
+        static_val: '{{repl if ConfigOptionEquals "authz_cache_enabled" "authz_cache_enabled_yes"}}true{{repl end}}'
+      - name: AUTHZ_CACHE_DEFAULT_TTL_SECONDS
+        static_val: '{{repl ConfigOption "authz_cache_ttl_seconds"}}'
     ports:
     - private_port: '5000'
       public_port: '5000'
@@ -1122,6 +1118,29 @@ config:
       type: text
       affix: right
       required: false
+- name: authcaching
+  title: Auth Caching
+  description: Should successful authorization checks be cached to prevent excessive load on the external auth provider for installs?
+  items:
+  - name: authz_cache_enabled
+    type: select_one
+    default: authz_cache_enabled_no
+    items:
+    - name: authz_cache_enabled_no
+      title: No
+      type: text
+      affix: left
+      required: false
+    - name: authz_cache_enabled_yes
+      title: Yes
+      type: text
+      affix: right
+      required: false
+  - name: authz_cache_ttl_seconds
+    title: Expiration (in seconds) for auth cache entries
+    type: text
+    when: authz_cache_enabled=authz_cache_enabled_yes
+    default: 600
 - name: allowpublishes
   title: Publication Settings
   description: 'What types of package publishes are allowed in this npm Enterprise instance: "All" allows scoped and global packages, "Read Only" blocks all publishes, "Scoped" allows only scoped package publications.'


### PR DESCRIPTION
Allow end users to enable caching of successful authorization checks to prevent excessive load on the external auth provider during `npm install`s. Defaults to disabled ("No").

When enabled, allow users to define the TTL period (in seconds).

Note that the OAuth2 authentication option has implicitly included caching since Stable release `f6785af (366)`. This change expands that capability to all authentication options (though it cannot currently be disabled for OAuth2) and allows users to change the TTL (for all auth options, including OAuth2).

This bumps the default cache TTL for OAuth2 from 5 minutes (300 seconds) to 10 minutes (600 seconds).

This is what the new config section looks like.

Disabled (default):
<img width="849" alt="screen shot 2017-01-27 at 5 08 59 pm" src="https://cloud.githubusercontent.com/assets/1929625/22389440/7f0364c0-e4b3-11e6-9a74-333df110e2b7.png">

Enabled:
<img width="852" alt="screen shot 2017-01-27 at 5 09 17 pm" src="https://cloud.githubusercontent.com/assets/1929625/22389450/8da2b148-e4b3-11e6-8031-208ad8f3952d.png">
