### PR TITLE
[WIP] fix: upgrade to policy-follower with fix for replica replication

### DIFF
--- a/replicated/policy-follower/Dockerfile
+++ b/replicated/policy-follower/Dockerfile
@@ -11,7 +11,7 @@ COPY ./replicated/policy-follower/reset-follower.sh /etc/npme/reset-follower.sh
 WORKDIR /etc/npme
 
 RUN echo '@npm:registry=https://enterprise.npmjs.com/' > ~/.npmrc
-RUN npm install @npm/policy-follower@1.2.3
+RUN npm install @npm/policy-follower@1.2.4
 RUN npm install @npm/package-whitelist@0.1.4
 RUN apk update
 RUN apk add curl

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -28,21 +28,21 @@ admin_commands:
   component: npme
   image:
     image_name: npmjs/policy-follower
-    version: '2.2.11'
+    version: '2.2.12'
 - alias: add-package
   command: [sh, /etc/npme/add-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: npmjs/policy-follower
-    version: '2.2.11'
+    version: '2.2.12'
 - alias: remove-package
   command: [sh, /etc/npme/remove-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: npmjs/policy-follower
-    version: '2.2.11'
+    version: '2.2.12'
 - alias: edit-homepage
   command: [sh, /etc/npme/homepage.sh]
   run_type: exec
@@ -279,7 +279,7 @@ components:
         when: '{{repl ConfigOptionNotEquals "etc_hosts_2_ip" "" }}'
   - source: public
     image_name: npmjs/policy-follower
-    version: '2.2.11'
+    version: '2.2.12'
     name: npme-pf
     privileged: false
     restart:

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -28,21 +28,21 @@ admin_commands:
   component: npme
   image:
     image_name: npmjs/policy-follower
-    version: '2.2.12'
+    version: '2.2.13'
 - alias: add-package
   command: [sh, /etc/npme/add-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: npmjs/policy-follower
-    version: '2.2.12'
+    version: '2.2.13'
 - alias: remove-package
   command: [sh, /etc/npme/remove-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: npmjs/policy-follower
-    version: '2.2.12'
+    version: '2.2.13'
 - alias: edit-homepage
   command: [sh, /etc/npme/homepage.sh]
   run_type: exec
@@ -279,7 +279,7 @@ components:
         when: '{{repl ConfigOptionNotEquals "etc_hosts_2_ip" "" }}'
   - source: public
     image_name: npmjs/policy-follower
-    version: '2.2.12'
+    version: '2.2.13'
     name: npme-pf
     privileged: false
     restart:


### PR DESCRIPTION
we should test this change thoroughly:

- [ ] does it actually fix the replication bug between enterprise.npmjs.com and registry.internal.npmjs.com?
- [ ] does replicating from npmjs.com still work?