### PR TITLE
feat: add the option to expose :6379 for easy session replication

### DIFF
--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -451,11 +451,11 @@ components:
     - private_port: '6379'
       public_port: '6379'
       interface: docker0
-      when: '{{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_no" }}'
+      when: '{{repl ConfigOptionEquals "redis_bind_all" "redis_bind_all_no" }}'
     - private_port: '6379'
       public_port: '6379'
       port_type: tcp
-      when: '{{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_yes" }}'
+      when: '{{repl ConfigOptionEquals "redis_bind_all" "redis_bind_all_yes" }}'
     volumes:
     - host_path: '{{repl ConfigOption "redis_host_path" }}'
       container_path: /data

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -451,6 +451,11 @@ components:
     - private_port: '6379'
       public_port: '6379'
       interface: docker0
+      when: '{{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_no" }}'
+    - private_port: '6379'
+      public_port: '6379'
+      port_type: tcp
+      when: '{{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_yes" }}'
     volumes:
     - host_path: '{{repl ConfigOption "redis_host_path" }}'
       container_path: /data
@@ -983,6 +988,24 @@ config:
     title: Policy to apply during replication (set to mirror to create a true replica).
     type: text
     default: 'white-list'
+- name: redis_bind_all
+  title: Expose Redis for Replication
+  description: Should Redis' replication port (:6379) be exposed (only do this on a closed network).
+  items:
+- name: redis_bind_all
+  type: select_one
+  default: redis_bind_all_no
+  items:
+  - name: redis_bind_all_no
+    title: No
+    type: text
+    affix: left
+    required: false
+  - name: redis_bind_all_yes
+    title: Yes
+    type: text
+    affix: right
+    required: false
 - name: read_through_cache
   title: Read Through Cache
   description: Should missing packages be returned from the upstream registry?

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -992,20 +992,20 @@ config:
   title: Expose Redis for Replication
   description: Should Redis' replication port (:6379) be exposed (only do this on a closed network).
   items:
-- name: redis_bind_all
-  type: select_one
-  default: redis_bind_all_no
-  items:
-  - name: redis_bind_all_no
-    title: No
-    type: text
-    affix: left
-    required: false
-  - name: redis_bind_all_yes
-    title: Yes
-    type: text
-    affix: right
-    required: false
+  - name: redis_bind_all
+    type: select_one
+    default: redis_bind_all_no
+    items:
+    - name: redis_bind_all_no
+      title: No
+      type: text
+      affix: left
+      required: false
+    - name: redis_bind_all_yes
+      title: Yes
+      type: text
+      affix: right
+      required: false
 - name: read_through_cache
   title: Read Through Cache
   description: Should missing packages be returned from the upstream registry?

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -448,7 +448,7 @@ components:
       - filename: /data/redis.conf
         contents: |-
           appendonly yes
-          {{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_yes" }}slaveof {{repl ConfigOption "redis_replication_host" }} 6379{{repl end }}
+          {{repl if ConfigOptionNotEquals "redis_replication_host" "" }}slaveof {{repl ConfigOption "redis_replication_host" }} 6379{{repl end }}
     customer_files: []
     env_vars: []
     ports:
@@ -1013,6 +1013,8 @@ config:
   - name: redis_replication_host
     type: text
     affix: left
+    required: false
+    value: ""
 - name: read_through_cache
   title: Read Through Cache
   description: Should missing packages be returned from the upstream registry?

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -450,12 +450,7 @@ components:
     ports:
     - private_port: '6379'
       public_port: '6379'
-      interface: docker0
-      when: '{{repl ConfigOptionEquals "redis_bind_all" "redis_bind_all_no" }}'
-    - private_port: '6379'
-      public_port: '6379'
-      port_type: tcp
-      when: '{{repl ConfigOptionEquals "redis_bind_all" "redis_bind_all_yes" }}'
+      interface: '{{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_no" }}docker0{{repl end }}'
     volumes:
     - host_path: '{{repl ConfigOption "redis_host_path" }}'
       container_path: /data
@@ -911,6 +906,8 @@ cmds:
 - name: publicip
   cmd: publicip
   args: []
+- name: setup-redis-replication
+  cmd: "redis-server{{if defined redis_replication_host}} --slaveof {{redis_replication_host}}{{end}}"
 config:
 - name: General
   title: "General"
@@ -1006,6 +1003,13 @@ config:
       type: text
       affix: right
       required: false
+- name: redis_replication_host
+  title: Expose Redis for Replication
+  description: Should Redis' replication port (:6379) be exposed (only do this on a closed network).
+  items:
+  - name: redis_replication_host
+    type: text
+    affix: left
 - name: read_through_cache
   title: Read Through Cache
   description: Should missing packages be returned from the upstream registry?

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -432,7 +432,7 @@ components:
     restart:
       policy: on-failure
       max: 50000
-    cmd: "[\"redis-server\", \"--appendonly\", \"yes\"]"
+    cmd: "[\"/usr/local/bin/redis-server\", \"/data/redis.conf\"]"
     publish_events:
     - name: Container redis started
       trigger: port-listen
@@ -444,13 +444,17 @@ components:
       - component: npme
         container: newww
         action: start
-    config_files: []
+    config_files:
+      - filename: /data/redis.conf
+        contents: |-
+          appendonly yes
+          {{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_yes" }}slaveof {{repl ConfigOption "redis_replication_host" }} 6379{{repl end }}
     customer_files: []
     env_vars: []
     ports:
     - private_port: '6379'
       public_port: '6379'
-      interface: '{{repl if ConfigOptionEquals "redis_bind_all" "redis_bind_all_no" }}docker0{{repl end }}'
+      interface: '{{repl if ConfigOptionNotEquals "redis_bind_all" "redis_bind_all_yes" }}docker0{{repl end }}'
     volumes:
     - host_path: '{{repl ConfigOption "redis_host_path" }}'
       container_path: /data
@@ -906,8 +910,6 @@ cmds:
 - name: publicip
   cmd: publicip
   args: []
-- name: setup-redis-replication
-  cmd: "redis-server{{if defined redis_replication_host}} --slaveof {{redis_replication_host}}{{end}}"
 config:
 - name: General
   title: "General"
@@ -1004,8 +1006,9 @@ config:
       affix: right
       required: false
 - name: redis_replication_host
-  title: Expose Redis for Replication
-  description: Should Redis' replication port (:6379) be exposed (only do this on a closed network).
+  when: redis_bind_all=redis_bind_all_yes
+  title: Upstream Redis
+  description: Which upstream Redis should sessions be replicated from?
   items:
   - name: redis_replication_host
     type: text

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -1006,7 +1006,6 @@ config:
       affix: right
       required: false
 - name: redis_replication_host
-  when: redis_bind_all=redis_bind_all_yes
   title: Upstream Redis
   description: Which upstream Redis should sessions be replicated from?
   items:


### PR DESCRIPTION
expose redis for replication, this makes our replication story much better because it allows folks to more easily replicate session tokens between instances.