### PR TITLE
Update postgres patch version

### DIFF
--- a/replicated/postgres/Dockerfile
+++ b/replicated/postgres/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /docker-entrypoint-initdb.d
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 ENV PG_MAJOR 9.3
-ENV PG_VERSION 9.3.10-1.pgdg80+1
+ENV PG_VERSION 9.3.17-1.pgdg80+1
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 


### PR DESCRIPTION
>Note: A new build is not needed to resolve this issue - I'm updating our source control to keep it in sync with reality 👍

Latest Docker no longer supports old school Docker v1 images (or at least Replicated's installer doesn't).

When trying to rebuild our postgres image, it blowed up. The original patch version we'd built on is no longer available.

Also, it is not clear why we're shipping our own one of these - I have made a mental note to revisit this at a later date.